### PR TITLE
Fixed zoom issue with Alt key and mouse wheel scroll

### DIFF
--- a/dwpicker/picker.py
+++ b/dwpicker/picker.py
@@ -219,7 +219,7 @@ class PickerView(QtWidgets.QWidget):
         # and compare the offset after zoom computation.
         if self.zoom_locked:
             return
-        factor = .25 if event.angleDelta().y() > 0 else -.25
+        factor = .25 if (event.angleDelta().x() if event.modifiers() & QtCore.Qt.AltModifier else event.angleDelta().y()) > 0 else -.25
         self.zoom(factor, event.pos())
         self.repaint()
 


### PR DESCRIPTION
When holding Alt and using the mouse wheel, the zoom was always -0.25. I updated the code to handle this properly by checking the scroll direction